### PR TITLE
Fix doctrine proxy namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "homepage": "https://github.com/myclabs/DeepCopy",
     "license": "MIT",
     "autoload": {
-        "psr-4": { "DeepCopy\\": "src/DeepCopy/" }
+        "psr-4": { "ProfideoDeepCopy\\": "src/DeepCopy/" }
     },
     "autoload-dev": {
-        "psr-4": { "DeepCopyTest\\": "tests/DeepCopyTest/" }
+        "psr-4": { "ProfideoDeepCopyTest\\": "tests/DeepCopyTest/" }
     },
     "require": {
         "php": ">=5.4.0"

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "myclabs/deep-copy",
+    "name": "profideo-ci/deep-copy",
     "type": "library",
     "description": "Create deep copies (clones) of your objects",
     "keywords": ["clone", "copy", "duplicate", "object", "object graph"],
-    "homepage": "https://github.com/myclabs/DeepCopy",
+    "homepage": "https://github.com/profideo-ci/DeepCopy",
     "license": "MIT",
     "autoload": {
         "psr-4": { "ProfideoDeepCopy\\": "src/DeepCopy/" }

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -6,7 +6,7 @@ use DeepCopy\Exception\CloneException;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
 use DeepCopy\TypeFilter\TypeFilter;
-use DeepCopy\TypeMatcher\TypeMatcher;
+use DeepCopy\TypeMatcher\TypeMatcherInterface;
 use ReflectionProperty;
 use DeepCopy\Reflection\ReflectionHelper;
 
@@ -65,7 +65,7 @@ class DeepCopy
         ];
     }
 
-    public function addTypeFilter(TypeFilter $filter, TypeMatcher $matcher)
+    public function addTypeFilter(TypeFilter $filter, TypeMatcherInterface $matcher)
     {
         $this->typeFilters[] = [
             'matcher' => $matcher,
@@ -194,7 +194,7 @@ class DeepCopy
         $matched = $this->first(
             $filterRecords,
             function (array $record) use ($var) {
-                /* @var TypeMatcher $matcher */
+                /* @var TypeMatcherInterface $matcher */
                 $matcher = $record['matcher'];
 
                 return $matcher->matches($var);

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace DeepCopy;
+namespace ProfideoDeepCopy;
 
-use DeepCopy\Exception\CloneException;
-use DeepCopy\Filter\Filter;
-use DeepCopy\Matcher\Matcher;
-use DeepCopy\TypeFilter\TypeFilter;
-use DeepCopy\TypeMatcher\TypeMatcherInterface;
+use ProfideoDeepCopy\Exception\CloneException;
+use ProfideoDeepCopy\Filter\Filter;
+use ProfideoDeepCopy\Matcher\Matcher;
+use ProfideoDeepCopy\TypeFilter\TypeFilter;
+use ProfideoDeepCopy\TypeMatcher\TypeMatcherInterface;
 use ReflectionProperty;
-use DeepCopy\Reflection\ReflectionHelper;
+use ProfideoDeepCopy\Reflection\ReflectionHelper;
 
 /**
  * DeepCopy

--- a/src/DeepCopy/Exception/CloneException.php
+++ b/src/DeepCopy/Exception/CloneException.php
@@ -1,5 +1,5 @@
 <?php
-namespace DeepCopy\Exception;
+namespace ProfideoDeepCopy\Exception;
 
 class CloneException extends \UnexpectedValueException
 {

--- a/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepCopy\Filter\Doctrine;
+namespace ProfideoDeepCopy\Filter\Doctrine;
 
-use DeepCopy\Filter\Filter;
+use ProfideoDeepCopy\Filter\Filter;
 use ReflectionProperty;
 
 /**

--- a/src/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepCopy\Filter\Doctrine;
+namespace ProfideoDeepCopy\Filter\Doctrine;
 
-use DeepCopy\Filter\Filter;
+use ProfideoDeepCopy\Filter\Filter;
 use Doctrine\Common\Collections\ArrayCollection;
 
 class DoctrineEmptyCollectionFilter implements Filter

--- a/src/DeepCopy/Filter/Filter.php
+++ b/src/DeepCopy/Filter/Filter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Filter;
+namespace ProfideoDeepCopy\Filter;
 
 /**
  * Filter to apply to a property while copying an object

--- a/src/DeepCopy/Filter/KeepFilter.php
+++ b/src/DeepCopy/Filter/KeepFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Filter;
+namespace ProfideoDeepCopy\Filter;
 
 /**
  * Keep the value of a property

--- a/src/DeepCopy/Filter/ReplaceFilter.php
+++ b/src/DeepCopy/Filter/ReplaceFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Filter;
+namespace ProfideoDeepCopy\Filter;
 
 /**
  * Replace the value of a property

--- a/src/DeepCopy/Filter/SetNullFilter.php
+++ b/src/DeepCopy/Filter/SetNullFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Filter;
+namespace ProfideoDeepCopy\Filter;
 
 use ReflectionProperty;
 

--- a/src/DeepCopy/Matcher/Matcher.php
+++ b/src/DeepCopy/Matcher/Matcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Matcher;
+namespace ProfideoDeepCopy\Matcher;
 
 /**
  * Matcher interface

--- a/src/DeepCopy/Matcher/PropertyMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyMatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Matcher;
+namespace ProfideoDeepCopy\Matcher;
 
 /**
  * Match a specific property of a specific class

--- a/src/DeepCopy/Matcher/PropertyNameMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyNameMatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Matcher;
+namespace ProfideoDeepCopy\Matcher;
 
 /**
  * Match a property by its name

--- a/src/DeepCopy/Matcher/PropertyTypeMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyTypeMatcher.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DeepCopy\Matcher;
+namespace ProfideoDeepCopy\Matcher;
 
 use ReflectionProperty;
 
 /**
  * Match a property by its type
  *
- * @deprecated It is recommended to use {@see DeepCopy\TypeFilter\TypeFilter} instead, as it applies on all occurrences
+ * @deprecated It is recommended to use {@see ProfideoDeepCopy\TypeFilter\TypeFilter} instead, as it applies on all occurrences
  *             of given type in copied context (eg. array elements), not just on object properties.
  */
 class PropertyTypeMatcher implements Matcher

--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -17,10 +17,22 @@ class ReflectionHelper
      */
     public static function getProperties(\ReflectionClass $ref)
     {
+        $isDoctrineProxy = false;
+        if (
+            interface_exists('Doctrine\Common\Persistence\Proxy') &&
+            $ref->implementsInterface('Doctrine\Common\Persistence\Proxy')
+        ) {
+            $isDoctrineProxy = true;
+        }
+
         $props = $ref->getProperties();
         $propsArr = array();
 
         foreach ($props as $prop) {
+            if ($isDoctrineProxy && !$ref->getParentClass()->hasProperty($prop->getName())) {
+                continue;
+            }
+
             $f = $prop->getName();
             $propsArr[$f] = $prop;
         }

--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\Reflection;
+namespace ProfideoDeepCopy\Reflection;
 
 class ReflectionHelper
 {

--- a/src/DeepCopy/TypeFilter/KeepFilter.php
+++ b/src/DeepCopy/TypeFilter/KeepFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DeepCopy\TypeFilter;
+
+class KeepFilter implements TypeFilter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function apply($element)
+    {
+        return $element;
+    }
+}

--- a/src/DeepCopy/TypeFilter/KeepFilter.php
+++ b/src/DeepCopy/TypeFilter/KeepFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\TypeFilter;
+namespace ProfideoDeepCopy\TypeFilter;
 
 class KeepFilter implements TypeFilter
 {

--- a/src/DeepCopy/TypeFilter/ReplaceFilter.php
+++ b/src/DeepCopy/TypeFilter/ReplaceFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\TypeFilter;
+namespace ProfideoDeepCopy\TypeFilter;
 
 class ReplaceFilter implements TypeFilter
 {

--- a/src/DeepCopy/TypeFilter/ShallowCopyFilter.php
+++ b/src/DeepCopy/TypeFilter/ShallowCopyFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\TypeFilter;
+namespace ProfideoDeepCopy\TypeFilter;
 
 class ShallowCopyFilter implements TypeFilter
 {

--- a/src/DeepCopy/TypeFilter/TypeFilter.php
+++ b/src/DeepCopy/TypeFilter/TypeFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\TypeFilter;
+namespace ProfideoDeepCopy\TypeFilter;
 
 interface TypeFilter
 {

--- a/src/DeepCopy/TypeMatcher/Doctrine/DoctrineProxyNotCloneableTypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/Doctrine/DoctrineProxyNotCloneableTypeMatcher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DeepCopy\TypeMatcher\Doctrine;
+
+use DeepCopy\TypeMatcher\TypeMatcherInterface;
+use Doctrine\Common\Persistence\Proxy;
+use ReflectionObject;
+
+class DoctrineProxyNotCloneableTypeMatcher implements TypeMatcherInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function matches($element)
+    {
+        if (!is_object($element) || !$element instanceof Proxy) {
+            return false;
+        }
+
+        $reflectionObject = new ReflectionObject($element);
+
+        if ($isCloneable = $reflectionObject->getParentClass()->isCloneable()) {
+            $element->__load();
+        }
+
+        return !$isCloneable;
+    }
+}

--- a/src/DeepCopy/TypeMatcher/Doctrine/DoctrineProxyNotCloneableTypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/Doctrine/DoctrineProxyNotCloneableTypeMatcher.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepCopy\TypeMatcher\Doctrine;
+namespace ProfideoDeepCopy\TypeMatcher\Doctrine;
 
-use DeepCopy\TypeMatcher\TypeMatcherInterface;
+use ProfideoDeepCopy\TypeMatcher\TypeMatcherInterface;
 use Doctrine\Common\Persistence\Proxy;
 use ReflectionObject;
 

--- a/src/DeepCopy/TypeMatcher/TypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcher.php
@@ -5,7 +5,7 @@ namespace DeepCopy\TypeMatcher;
 /**
  * TypeMatcher class
  */
-class TypeMatcher
+class TypeMatcher implements TypeMatcherInterface
 {
     /**
      * @var string
@@ -21,8 +21,7 @@ class TypeMatcher
     }
 
     /**
-     * @param $element
-     * @return boolean
+     * {@inheritdoc}
      */
     public function matches($element)
     {

--- a/src/DeepCopy/TypeMatcher/TypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\TypeMatcher;
+namespace ProfideoDeepCopy\TypeMatcher;
 
 /**
  * TypeMatcher class

--- a/src/DeepCopy/TypeMatcher/TypeMatcherInterface.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcherInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DeepCopy\TypeMatcher;
+
+interface TypeMatcherInterface
+{
+    /**
+     * @param $element
+     *
+     * @return boolean
+     */
+    public function matches($element);
+}

--- a/src/DeepCopy/TypeMatcher/TypeMatcherInterface.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcherInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeepCopy\TypeMatcher;
+namespace ProfideoDeepCopy\TypeMatcher;
 
 interface TypeMatcherInterface
 {

--- a/tests/DeepCopyTest/AbstractTestClass.php
+++ b/tests/DeepCopyTest/AbstractTestClass.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DeepCopyTest;
+namespace ProfideoDeepCopyTest;
 
-use DeepCopy\Reflection\ReflectionHelper;
+use ProfideoDeepCopy\Reflection\ReflectionHelper;
 
 /**
  * Abstract test class

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DeepCopyTest;
+namespace ProfideoDeepCopyTest;
 
-use DeepCopy\DeepCopy;
-use DeepCopy\Filter\Filter;
-use DeepCopy\Matcher\PropertyMatcher;
-use DeepCopy\TypeFilter\TypeFilter;
-use DeepCopy\TypeMatcher\TypeMatcher;
+use ProfideoDeepCopy\DeepCopy;
+use ProfideoDeepCopy\Filter\Filter;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\TypeFilter\TypeFilter;
+use ProfideoDeepCopy\TypeMatcher\TypeMatcher;
 
 /**
  * DeepCopyTest
@@ -111,15 +111,15 @@ class DeepCopyTest extends AbstractTestClass
 
     public function testNonClonableItems()
     {
-        $a = new \ReflectionClass('DeepCopyTest\A');
+        $a = new \ReflectionClass('ProfideoDeepCopyTest\A');
         $deepCopy = new DeepCopy();
         $a2 = $deepCopy->skipUncloneable()->copy($a);
         $this->assertSame($a, $a2);
     }
 
     /**
-     * @expectedException \DeepCopy\Exception\CloneException
-     * @expectedExceptionMessage Class "DeepCopyTest\C" is not cloneable.
+     * @expectedException \ProfideoDeepCopy\Exception\CloneException
+     * @expectedExceptionMessage Class "ProfideoDeepCopyTest\C" is not cloneable.
      */
     public function testCloneException()
     {
@@ -136,7 +136,7 @@ class DeepCopyTest extends AbstractTestClass
         $o = new A();
         $o->property1 = 'foo';
 
-        $filter = $this->getMockForAbstractClass('DeepCopy\Filter\Filter');
+        $filter = $this->getMockForAbstractClass('ProfideoDeepCopy\Filter\Filter');
         $filter->expects($this->once())
             ->method('apply')
             ->will($this->returnCallback(function($object, $property) {
@@ -161,7 +161,7 @@ class DeepCopyTest extends AbstractTestClass
         $o->property1 = new B();
 
         /* @var Filter|\PHPUnit_Framework_MockObject_MockObject $filter */
-        $filter = $this->getMockForAbstractClass('DeepCopy\Filter\Filter');
+        $filter = $this->getMockForAbstractClass('ProfideoDeepCopy\Filter\Filter');
         $filter->expects($this->once())
             ->method('apply')
             ->will($this->returnCallback(function($object, $property, $objectCopier) {
@@ -184,13 +184,13 @@ class DeepCopyTest extends AbstractTestClass
         $o->property1 = new B();
 
         /* @var TypeFilter|\PHPUnit_Framework_MockObject_MockObject $filter */
-        $filter = $this->getMockForAbstractClass('DeepCopy\TypeFilter\TypeFilter');
+        $filter = $this->getMockForAbstractClass('ProfideoDeepCopy\TypeFilter\TypeFilter');
         $filter->expects($this->once())
             ->method('apply')
             ->will($this->returnValue(null));
 
         $deepCopy = new DeepCopy();
-        $deepCopy->addTypeFilter($filter, new TypeMatcher('DeepCopyTest\B'));
+        $deepCopy->addTypeFilter($filter, new TypeMatcher('ProfideoDeepCopyTest\B'));
         /** @var A $new */
         $new = $deepCopy->copy($o);
 
@@ -205,13 +205,13 @@ class DeepCopyTest extends AbstractTestClass
         $arr = [new A, new A, new B, new B, new A];
 
         /* @var TypeFilter|\PHPUnit_Framework_MockObject_MockObject $filter */
-        $filter = $this->getMockForAbstractClass('DeepCopy\TypeFilter\TypeFilter');
+        $filter = $this->getMockForAbstractClass('ProfideoDeepCopy\TypeFilter\TypeFilter');
         $filter->expects($this->exactly(2))
             ->method('apply')
             ->will($this->returnValue(null));
 
         $deepCopy = new DeepCopy();
-        $deepCopy->addTypeFilter($filter, new TypeMatcher('DeepCopyTest\B'));
+        $deepCopy->addTypeFilter($filter, new TypeMatcher('ProfideoDeepCopyTest\B'));
         /** @var A $new */
         $new = $deepCopy->copy($arr);
 

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DeepCopyTest\Filter\Doctrine;
+namespace ProfideoDeepCopyTest\Filter\Doctrine;
 
-use DeepCopy\DeepCopy;
-use DeepCopy\Filter\Doctrine\DoctrineCollectionFilter;
-use DeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\DeepCopy;
+use ProfideoDeepCopy\Filter\Doctrine\DoctrineCollectionFilter;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DeepCopyTest\Filter\Doctrine;
+namespace ProfideoDeepCopyTest\Filter\Doctrine;
 
-use DeepCopy\DeepCopy;
-use DeepCopy\Filter\Doctrine\DoctrineEmptyCollectionFilter;
-use DeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\DeepCopy;
+use ProfideoDeepCopy\Filter\Doctrine\DoctrineEmptyCollectionFilter;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 

--- a/tests/DeepCopyTest/Filter/KeepFilterTest.php
+++ b/tests/DeepCopyTest/Filter/KeepFilterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DeepCopyTest\Filter;
+namespace ProfideoDeepCopyTest\Filter;
 
-use DeepCopy\DeepCopy;
-use DeepCopy\Filter\KeepFilter;
-use DeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\DeepCopy;
+use ProfideoDeepCopy\Filter\KeepFilter;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
 
 /**
  * Test Keep filter

--- a/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DeepCopyTest\Filter;
+namespace ProfideoDeepCopyTest\Filter;
 
-use DeepCopy\DeepCopy;
-use DeepCopy\Filter\ReplaceFilter;
-use DeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\DeepCopy;
+use ProfideoDeepCopy\Filter\ReplaceFilter;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
 
 class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
 {
@@ -34,7 +34,7 @@ class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
 
         return [
             [$closure, ['foo' => 'bar']],
-            ['DeepCopyTest\Filter\Callback::copy', ['foo' => 'bar', 'baz' => 'foo', 'foobar' => 'baz']],
+            ['ProfideoDeepCopyTest\Filter\Callback::copy', ['foo' => 'bar', 'baz' => 'foo', 'foobar' => 'baz']],
             [[new Callback(), 'callback'], ['foo' => 'foo']]
         ];
     }

--- a/tests/DeepCopyTest/Filter/SetNullFilterTest.php
+++ b/tests/DeepCopyTest/Filter/SetNullFilterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DeepCopyTest\Filter;
+namespace ProfideoDeepCopyTest\Filter;
 
-use DeepCopy\DeepCopy;
-use DeepCopy\Filter\SetNullFilter;
-use DeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\DeepCopy;
+use ProfideoDeepCopy\Filter\SetNullFilter;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
 
 /**
  * Test SetNull filter

--- a/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace DeepCopyTest\Matcher;
+namespace ProfideoDeepCopyTest\Matcher;
 
-use DeepCopy\Matcher\PropertyMatcher;
+use ProfideoDeepCopy\Matcher\PropertyMatcher;
 
 /**
  * Test PropertyMatcher
@@ -10,7 +10,7 @@ class PropertyMatcherTest extends \PHPUnit_Framework_TestCase
 {
     public function testMatches()
     {
-        $matcher = new PropertyMatcher('DeepCopyTest\Matcher\PropertyMatcherTestFixture', 'property1');
+        $matcher = new PropertyMatcher('ProfideoDeepCopyTest\Matcher\PropertyMatcherTestFixture', 'property1');
 
         $this->assertTrue($matcher->matches(new PropertyMatcherTestFixture(), 'property1'));
         $this->assertFalse($matcher->matches(new \stdClass(), 'property1'));

--- a/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace DeepCopyTest\Matcher;
+namespace ProfideoDeepCopyTest\Matcher;
 
-use DeepCopy\Matcher\PropertyNameMatcher;
+use ProfideoDeepCopy\Matcher\PropertyNameMatcher;
 
 /**
  * Test PropertyNameMatcher

--- a/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace DeepCopyTest\Matcher;
+namespace ProfideoDeepCopyTest\Matcher;
 
-use DeepCopy\Matcher\PropertyTypeMatcher;
+use ProfideoDeepCopy\Matcher\PropertyTypeMatcher;
 
 /**
  * Test PropertyNameMatcher
@@ -10,7 +10,7 @@ class PropertyTypeMatcherTest extends \PHPUnit_Framework_TestCase
 {
     public function testMatches()
     {
-        $matcher = new PropertyTypeMatcher('DeepCopyTest\Matcher\PropertyTypeMatcherTestFixture2');
+        $matcher = new PropertyTypeMatcher('ProfideoDeepCopyTest\Matcher\PropertyTypeMatcherTestFixture2');
 
         $o = new PropertyTypeMatcherTestFixture1();
         $this->assertFalse($matcher->matches($o, 'property1'));


### PR DESCRIPTION
Fix old Doctrine proxy bug while waiting for the 2.0.
Change namespace to allow us to upgrade PHPUnit which require DeepCopy (since version 5).